### PR TITLE
feat: update use command

### DIFF
--- a/src/commands/use.ts
+++ b/src/commands/use.ts
@@ -41,10 +41,10 @@ export default class UseCommand extends UpdateCommand {
     const matchingLocalVersions = versions
     .filter(version => version.includes(targetVersion))
     .sort((a, b) => semver.compare(b, a))
+    const target = versions.includes(targetVersion) ? targetVersion : matchingLocalVersions[0]
 
     if (versions.includes(targetVersion) || matchingLocalVersions.length > 0) {
-      const target = versions.includes(targetVersion) ? targetVersion : matchingLocalVersions[0]
-      this.updateToExistingVersion(target)
+      await this.updateToExistingVersion(target)
       this.currentVersion = await this.determineCurrentVersion()
       this.updatedVersion = target
     } else if (channelUpdateRequested) {

--- a/src/commands/use.ts
+++ b/src/commands/use.ts
@@ -41,9 +41,9 @@ export default class UseCommand extends UpdateCommand {
     const matchingLocalVersions = versions
     .filter(version => version.includes(targetVersion))
     .sort((a, b) => semver.compare(b, a))
-    const target = versions.includes(targetVersion) ? targetVersion : matchingLocalVersions[0]
 
     if (versions.includes(targetVersion) || matchingLocalVersions.length > 0) {
+      const target = versions.includes(targetVersion) ? targetVersion : matchingLocalVersions[0]
       await this.updateToExistingVersion(target)
       this.currentVersion = await this.determineCurrentVersion()
       this.updatedVersion = target

--- a/src/commands/use.ts
+++ b/src/commands/use.ts
@@ -5,67 +5,86 @@ import * as semver from 'semver'
 import UpdateCommand from './update'
 
 export default class UseCommand extends UpdateCommand {
-    static args = [{name: 'version', optional: false}]
+  static args = [{name: 'version', optional: false}];
 
-    static flags = {}
+  static flags = {};
 
-    async run() {
-      const {args} = this.parse(UseCommand)
+  async run() {
+    const {args} = this.parse(UseCommand)
 
-      // Check if this command is trying to update the channel. TODO: make this dynamic
-      const channelUpdateRequested = ['alpha', 'beta', 'next', 'stable'].some(c => args.version === c)
-      this.channel = channelUpdateRequested ? args.version : await this.determineChannel()
+    // Check if this command is trying to update the channel. TODO: make this dynamic
+    const channelUpdateRequested = ['alpha', 'beta', 'next', 'stable'].some(
+      c => args.version === c,
+    )
+    this.channel = channelUpdateRequested ?
+      args.version :
+      await this.determineChannel()
 
-      const targetVersion = semver.clean(args.version) || args.version
+    const targetVersion = semver.clean(args.version) || args.version
 
-      // Determine if the version is from a different channel and update to account for it (ex. cli-example update 3.0.0-next.22 should update the channel to next as well.)
-      const versionParts = targetVersion?.split('-') || ['', '']
-      if (versionParts && versionParts[1]) {
-        this.channel = versionParts[1].substr(0, versionParts[1].indexOf('.'))
-        this.debug(`Flag overriden target channel: ${this.channel}`)
-      }
-
-      await this.ensureClientDir()
-      this.debug(`Looking for locally installed versions at ${this.clientRoot}`)
-
-      // Do not show known non-local version folder names, bin and current.
-      const versions = fs.readdirSync(this.clientRoot).filter(dirOrFile => dirOrFile !== 'bin' && dirOrFile !== 'current')
-      if (versions.length === 0) throw new Error('No locally installed versions found.')
-
-      if (versions.includes(targetVersion)) {
-        this.updateToExistingVersion(targetVersion)
-      } else if (channelUpdateRequested) {
-        // Begin prompt
-        cli.action.start(`${this.config.name}: Updating CLI`)
-
-        // Run pre-update hook
-        await this.config.runHook('preupdate', {channel: this.channel})
-        const manifest = await this.fetchManifest()
-
-        // Determine version differences
-        this.currentVersion = await this.determineCurrentVersion()
-        this.updatedVersion = (manifest as any).sha ? `${manifest.version}-${(manifest as any).sha}` : manifest.version
-
-        // Check if this update should be skipped
-        const reason = await this.skipUpdate()
-        if (reason) {
-          cli.action.stop(reason || 'done')
-        } else {
-          // Update using the new channel specification
-          await this.update(manifest, this.channel)
-        }
-
-        this.debug('tidy')
-        await this.tidy()
-        await this.config.runHook('update', {channel: this.channel})
-      } else {
-        throw new Error(`Requested version could not be found. Please try running \`${this.config.bin} install ${targetVersion}\``)
-      }
-
-      this.log()
-      this.log(`Updating to an already installed version will not update the channel. If autoupdate is enabled, the CLI will eventually be updated back to ${this.channel}.`)
-
-      this.debug('done')
-      cli.action.stop()
+    // Determine if the version is from a different channel and update to account for it (ex. cli-example update 3.0.0-next.22 should update the channel to next as well.)
+    const versionParts = targetVersion?.split('-') || ['', '']
+    if (versionParts && versionParts[1]) {
+      this.channel = versionParts[1].substr(0, versionParts[1].indexOf('.'))
+      this.debug(`Flag overriden target channel: ${this.channel}`)
     }
+
+    await this.ensureClientDir()
+    this.debug(`Looking for locally installed versions at ${this.clientRoot}`)
+
+    // Do not show known non-local version folder names, bin and current.
+    const versions = fs
+    .readdirSync(this.clientRoot)
+    .filter(dirOrFile => dirOrFile !== 'bin' && dirOrFile !== 'current')
+    if (versions.length === 0)
+      throw new Error('No locally installed versions found.')
+    const matchingLocalVersions = versions
+    .filter(version => version.includes(targetVersion))
+    .sort((a, b) => semver.compare(b, a))
+
+    if (versions.includes(targetVersion) || matchingLocalVersions.length > 0) {
+      const target = versions.includes(targetVersion) ? targetVersion : matchingLocalVersions[0]
+      this.updateToExistingVersion(target)
+      this.currentVersion = await this.determineCurrentVersion()
+      this.updatedVersion = target
+    } else if (channelUpdateRequested) {
+      // Begin prompt
+      cli.action.start(`${this.config.name}: Updating CLI`)
+
+      // Run pre-update hook
+      await this.config.runHook('preupdate', {channel: this.channel})
+      const manifest = await this.fetchManifest()
+
+      // Determine version differences
+      this.currentVersion = await this.determineCurrentVersion()
+      this.updatedVersion = (manifest as any).sha ?
+        `${manifest.version}-${(manifest as any).sha}` :
+        manifest.version
+
+      // Check if this update should be skipped
+      const reason = await this.skipUpdate()
+      if (reason) {
+        cli.action.stop(reason || 'done')
+      } else {
+        // Update using the new channel specification
+        await this.update(manifest, this.channel)
+      }
+
+      this.debug('tidy')
+      await this.tidy()
+      await this.config.runHook('update', {channel: this.channel})
+    } else {
+      throw new Error(
+        `Requested version could not be found. Please try running \`${this.config.bin} install ${targetVersion}\``,
+      )
+    }
+
+    this.log()
+    this.log(
+      `Updating to an already installed version will not update the channel. If autoupdate is enabled, the CLI will eventually be updated back to ${this.channel}.`,
+    )
+
+    this.debug('done')
+    cli.action.stop()
+  }
 }

--- a/test/commands/use.test.ts
+++ b/test/commands/use.test.ts
@@ -46,7 +46,6 @@ describe('Use Command', () => {
       bin: 'cli',
       scopedEnvVarKey: jest.fn(),
       scopedEnvVar: jest.fn(),
-
     } as any
   })
 

--- a/test/commands/use.test.ts
+++ b/test/commands/use.test.ts
@@ -66,6 +66,7 @@ describe('Use Command', () => {
 
     expect(commandInstance.downloadAndExtract).not.toBeCalled()
     expect(commandInstance.updatedVersion).toBe('1.0.0-next.3')
+    expect(commandInstance.channel).toBe('next')
   })
 
   it('when provided a version, will directly switch to it locally', async () => {
@@ -137,24 +138,5 @@ describe('Use Command', () => {
 
     expect(commandInstance.downloadAndExtract).not.toBeCalled()
     expect(err.message).toBe('Requested version could not be found. Please try running `cli install blah`')
-  })
-
-  it('when provided a channel, updates the channel even if local versions do not have channel', async () => {
-    mockFs.readdirSync.mockReturnValue([
-      '1.0.0-next.2',
-      '1.0.0-next.3',
-      '1.0.1',
-      '1.0.0-alpha.0',
-    ] as any)
-
-    // oclif-example use next
-    commandInstance = new MockedUseCommand(['beta'], config)
-
-    commandInstance.fetchManifest.mockResolvedValue({})
-
-    await commandInstance.run()
-
-    expect(commandInstance.downloadAndExtract).not.toBeCalled()
-    expect(commandInstance.channel).toBe('beta')
   })
 })


### PR DESCRIPTION
## What does this change do and why
-  add logic so that when provided a channel, `use` command  uses the latest version available locally
-  update `use` command tests 
