### PR TITLE
fix: strip partial installation from version resolution

### DIFF
--- a/src/commands/use.ts
+++ b/src/commands/use.ts
@@ -21,7 +21,7 @@ export default class UseCommand extends UpdateCommand {
       args.version :
       await this.determineChannel()
 
-    const targetVersion = semver.clean(args.version) || args.version
+    const targetVersion = semver.clean(args.version || '') || args.version
 
     // Determine if the version is from a different channel and update to account for it (ex. cli-example update 3.0.0-next.22 should update the channel to next as well.)
     const versionParts = targetVersion?.split('-') || ['', '']
@@ -40,8 +40,18 @@ export default class UseCommand extends UpdateCommand {
     if (versions.length === 0)
       throw new Error('No locally installed versions found.')
     const matchingLocalVersions = versions
-    // If we request stable, only provide standard versions
-    .filter(version => (this.channel === 'stable' &&  !prereleaseChannels.some(c => version.includes(c))) || (version.includes(targetVersion) && !version.includes('.partial')))
+    .filter(version => {
+      // - If the version contains 'partial', ignore it
+      if (version.includes('partial')) {
+        return false
+      }
+      // - If we request stable, only provide standard versions...
+      if (this.channel === 'stable') {
+        return !prereleaseChannels.some(c => version.includes(c))
+      }
+      // - ... otherwise check if the version is contained
+      return version.includes(targetVersion)
+    })
     .sort((a, b) => semver.compare(b, a))
 
     if (args.version && (versions.includes(targetVersion) || matchingLocalVersions.length > 0)) {

--- a/test/commands/use.test.ts
+++ b/test/commands/use.test.ts
@@ -143,6 +143,54 @@ describe('Use Command', () => {
     expect(err.message).toBe(`Requested version could not be found locally. ${localVersionsMsg}`)
   })
 
+  it('will ignore partials when trying to update to stable', async () => {
+    mockFs.readdirSync.mockReturnValue([
+      '1.0.0-next.2',
+      '1.0.0-next.3',
+      '1.0.1',
+      '1.0.2.partial.0000',
+      '1.0.1.partial.0000',
+      '1.0.0-alpha.0',
+    ] as any)
+
+    // oclif-example use '1.0.0-alpha.0'
+    commandInstance = new MockedUseCommand(['stable'], config)
+
+    commandInstance.fetchManifest.mockResolvedValue({
+      channel: 'stable',
+    } as IManifest)
+
+    await commandInstance.run()
+
+    expect(commandInstance.downloadAndExtract).not.toBeCalled()
+    expect(commandInstance.updatedVersion).toBe('1.0.1')
+  })
+
+  it('will ignore partials when trying to update to a prerelease', async () => {
+    mockFs.readdirSync.mockReturnValue([
+      '1.0.0-next.2',
+      '1.0.0-next.3',
+      '1.0.1',
+      '1.0.2.partial.0000',
+      '1.0.1.partial.0000',
+      '1.0.0-alpha.0',
+      '1.0.0-alpha.1.partial.0',
+      '1.0.0-alpha.2.partial.12',
+    ] as any)
+
+    // oclif-example use '1.0.0-alpha.0'
+    commandInstance = new MockedUseCommand(['alpha'], config)
+
+    commandInstance.fetchManifest.mockResolvedValue({
+      channel: 'stable',
+    } as IManifest)
+
+    await commandInstance.run()
+
+    expect(commandInstance.downloadAndExtract).not.toBeCalled()
+    expect(commandInstance.updatedVersion).toBe('1.0.0-alpha.0')
+  })
+
   it('will print a warning when the requested channel is not available locally', async () => {
     mockFs.readdirSync.mockReturnValue([
       '1.0.0-next.2',


### PR DESCRIPTION
This ensures that `.partial` versions will not be fetched.