### PR TITLE
fix: strict prerelease channels

### DIFF
--- a/src/commands/use.ts
+++ b/src/commands/use.ts
@@ -4,6 +4,8 @@ import * as semver from 'semver'
 
 import UpdateCommand from './update'
 
+const SEMVER_REGEX = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?/
+
 export default class UseCommand extends UpdateCommand {
   static args = [{name: 'version', optional: false}];
 
@@ -14,9 +16,17 @@ export default class UseCommand extends UpdateCommand {
 
     // Check if this command is trying to update the channel. TODO: make this dynamic
     const prereleaseChannels = ['alpha', 'beta', 'next']
+    const isExplicitVersion = SEMVER_REGEX.test(args.version || '')
     const channelUpdateRequested = ['stable', ...prereleaseChannels].some(
       c => args.version === c,
     )
+
+    if (!isExplicitVersion && !channelUpdateRequested) {
+      throw new Error(
+        `Invalid argument provided: ${args.version}. Please specify either a valid channel (alpha, beta, next, stable) or an explicit version (ex. 2.68.13)`,
+      )
+    }
+
     this.channel = channelUpdateRequested ?
       args.version :
       await this.determineChannel()

--- a/test/commands/use.test.ts
+++ b/test/commands/use.test.ts
@@ -152,7 +152,7 @@ describe('Use Command', () => {
     ] as any)
 
     // oclif-example use test
-    commandInstance = new MockedUseCommand(['test'], config)
+    commandInstance = new MockedUseCommand(['beta'], config)
 
     commandInstance.fetchManifest.mockResolvedValue({})
 
@@ -173,5 +173,30 @@ describe('Use Command', () => {
 
     expect(commandInstance.downloadAndExtract).not.toBeCalled()
     expect(err.message).toBe(`Requested version could not be found locally. ${localVersionsMsg}`)
+  })
+
+  it('will throw an error when invalid channel is provided', async () => {
+    mockFs.readdirSync.mockReturnValue([
+      '1.0.0-next.2',
+      '1.0.0-next.3',
+      '1.0.1',
+      '1.0.0-alpha.0',
+    ] as any)
+
+    // oclif-example use test
+    commandInstance = new MockedUseCommand(['test'], config)
+
+    commandInstance.fetchManifest.mockResolvedValue({})
+
+    let err
+
+    try {
+      await commandInstance.run()
+    } catch (error) {
+      err = error
+    }
+
+    expect(commandInstance.downloadAndExtract).not.toBeCalled()
+    expect(err.message).toBe('Invalid argument provided: test. Please specify either a valid channel (alpha, beta, next, stable) or an explicit version (ex. 2.68.13)')
   })
 })


### PR DESCRIPTION
This catches if an invalid channel version is provided.