### PR TITLE
fix: only switch to stable if !channelUpdateRequested 

### DIFF
--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -37,7 +37,7 @@ export default class InstallCommand extends UpdateCommand {
     if (versionParts && versionParts[1]) {
       this.channel = versionParts[1].substr(0, versionParts[1].indexOf('.'));
       this.debug(`Flag overriden target channel: ${this.channel}`);
-    } else if (versionParts.length === 1) {
+    } else if (versionParts.length === 1 && !channelUpdateRequested) {
       // If there is only one version part then the channel must be stable
       this.channel = 'stable';
     }

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -38,7 +38,7 @@ export default class InstallCommand extends UpdateCommand {
       this.channel = versionParts[1].substr(0, versionParts[1].indexOf('.'));
       this.debug(`Flag overriden target channel: ${this.channel}`);
     } else if (versionParts.length === 1 && !channelUpdateRequested) {
-      // If there is only one version part then the channel must be stable
+      // If there is only one version part and !channelUpdateRequested then the channel must be stable
       this.channel = 'stable';
     }
 

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -193,7 +193,12 @@ export default class UpdateCommand extends Command {
         platform: this.config.platform,
         arch: this.config.arch,
       });
-    const extraction = extract(stream, baseDir, output, manifest.sha256gz);
+    const extraction = extract(
+      stream,
+      baseDir,
+      output,
+      !targetVersion && manifest.sha256gz ? manifest.sha256gz : undefined,
+    );
 
     // to-do: use cli.action.type
     if ((cli.action as any).frames) {


### PR DESCRIPTION
- if `channelUpdateRequested`, then do not set channel to stable as `next` or other non-stable channel e.g. when running `cli install next`