### PR TITLE
feat: add clean no-arg result for use command

### DIFF
--- a/src/commands/use.ts
+++ b/src/commands/use.ts
@@ -7,6 +7,11 @@ import UpdateCommand from './update';
 const SEMVER_REGEX =
   /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?/;
 
+const STRIP_SHA_REGEX = /(\d+)\.(\d+)\.(\d+)(\-\w+\.\d+)?/;
+
+const generateList = (items) => items.map((i) => `\t${i}`).join('\n');
+
+const PRERELEASE_CHANNELS = ['alpha', 'beta', 'next'];
 export default class UseCommand extends UpdateCommand {
   static args = [{ name: 'version', optional: false }];
 
@@ -15,10 +20,31 @@ export default class UseCommand extends UpdateCommand {
   async run() {
     const { args } = this.parse(UseCommand);
 
+    // Do not show known non-local version folder names, bin and current.
+    const versions = fs
+      .readdirSync(this.clientRoot)
+      .filter((dirOrFile) => dirOrFile !== 'bin' && dirOrFile !== 'current');
+    if (versions.length === 0) {
+      throw new Error('No locally installed versions found.');
+    }
+
+    if (!args.version) {
+      throw new Error(
+        `No version or channel was specified. Please choose from the following:\n${generateList(
+          ['stable', ...PRERELEASE_CHANNELS, ...versions]
+            .filter((v) => v.indexOf('partial') < 0)
+            .map((v) => {
+              const stripRegexMatch = v.match(STRIP_SHA_REGEX);
+              return (stripRegexMatch && stripRegexMatch[0]) || v;
+            }),
+        )}`,
+      );
+    }
+
     // Check if this command is trying to update the channel. TODO: make this dynamic
-    const prereleaseChannels = ['alpha', 'beta', 'next'];
+
     const isExplicitVersion = SEMVER_REGEX.test(args.version || '');
-    const channelUpdateRequested = ['stable', ...prereleaseChannels].some(
+    const channelUpdateRequested = ['stable', ...PRERELEASE_CHANNELS].some(
       (c) => args.version === c,
     );
 
@@ -44,12 +70,6 @@ export default class UseCommand extends UpdateCommand {
     await this.ensureClientDir();
     this.debug(`Looking for locally installed versions at ${this.clientRoot}`);
 
-    // Do not show known non-local version folder names, bin and current.
-    const versions = fs
-      .readdirSync(this.clientRoot)
-      .filter((dirOrFile) => dirOrFile !== 'bin' && dirOrFile !== 'current');
-    if (versions.length === 0)
-      throw new Error('No locally installed versions found.');
     const matchingLocalVersions = versions
       .filter((version) => {
         // - If the version contains 'partial', ignore it
@@ -58,7 +78,7 @@ export default class UseCommand extends UpdateCommand {
         }
         // - If we request stable, only provide standard versions...
         if (this.channel === 'stable') {
-          return !prereleaseChannels.some((c) => version.includes(c));
+          return !PRERELEASE_CHANNELS.some((c) => version.includes(c));
         }
         // - ... otherwise check if the version is contained
         return version.includes(targetVersion);


### PR DESCRIPTION
Provides the following when the CLI `use` command is passed no args
```
plugin-cli use
    Error: No version or channel was specified. Please choose from the following:
    	stable
    	alpha
    	beta
    	next
    	2.68.13
    	3.0.0-alpha.5
    	3.0.0-beta.4
    	3.0.0-next.40
    	3.0.0-next.41
    	3.0.0-next.46
```