### PR TITLE
fix: code organization and prep for requests around installation aliases

### DIFF
--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -10,6 +10,7 @@ import * as path from 'path';
 
 import { extract } from '../tar';
 import { ls, wait } from '../util';
+import { isSemverAlias } from '../utils/version-calculation';
 
 export default class UpdateCommand extends Command {
   static description =
@@ -56,6 +57,12 @@ export default class UpdateCommand extends Command {
     if (this.autoupdate) await this.debounce();
 
     this.channel = args.channel || (await this.determineChannel());
+
+    if (await isSemverAlias(this.channel)) {
+      throw new Error(
+        `We do not yet support major/minor aliases with the update command. Please refer to this issue for updates on the enhancement: https://github.com/sumwatshade/plugin-update/issues/32`,
+      );
+    }
 
     if (flags['from-local']) {
       await this.ensureClientDir();

--- a/src/commands/use.ts
+++ b/src/commands/use.ts
@@ -1,11 +1,7 @@
 import cli from 'cli-ux';
 import * as fs from 'fs-extra';
 import * as semver from 'semver';
-import {
-  EXTENDED_SEMVER_REGEX,
-  FUZZY_SEMVER_REGEX,
-  getMatchingVersions,
-} from '../utils/version-calculation';
+import { getMatchingVersions, isAnySemver } from '../utils/version-calculation';
 
 import UpdateCommand from './update';
 
@@ -29,14 +25,12 @@ export default class UseCommand extends UpdateCommand {
 
     // Check if this command is trying to update the channel. TODO: make this dynamic
     const prereleaseChannels = ['alpha', 'beta', 'next'];
-    const isExplicitVersion =
-      EXTENDED_SEMVER_REGEX.test(args.version || '') ||
-      FUZZY_SEMVER_REGEX.test(args.version || '');
+    const isArgSemver = await isAnySemver(args.version ?? '');
     const channelUpdateRequested = ['stable', ...prereleaseChannels].some(
       (c) => args.version === c,
     );
 
-    if (!isExplicitVersion && !channelUpdateRequested) {
+    if (!isArgSemver && !channelUpdateRequested) {
       throw new Error(
         `Invalid argument provided: ${args.version}. Please specify either a valid channel (alpha, beta, next, stable) or an explicit version (ex. 2.68.13)`,
       );

--- a/src/utils/version-calculation.ts
+++ b/src/utils/version-calculation.ts
@@ -1,11 +1,64 @@
 import * as semver from 'semver';
 
+/**
+ * Extended Semvers can optionally include prereleases
+ * @example 2.3.0
+ * @example 3.0.0-next.123
+ * @example 3.4.5-alpha
+ */
 const EXTENDED_SEMVER_REGEX =
   /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?/;
 
+/**
+ * Explicit semvers can be any major/minor/patch semver
+ *
+ * @example 2.1.0
+ * @example 1.2.3
+ * @example 21.10.333
+ */
 const SEMVER_REGEX = /^(\d+)\.(\d+)\.(\d+)$/;
 
+/**
+ * Fuzzy semvers can be any (potentially truncated) major/minor/patch semver
+ *
+ * @example 2.1.0
+ * @example 2.0
+ * @example 2
+ */
 const FUZZY_SEMVER_REGEX = /^(\d+)\.?(\d+)?\.?(\d+)?$/;
+
+/**
+ * Verifies if a version string is an explicit semver
+ *
+ * @param version The tested version string
+ * @returns If the version is an explicit semver @see {SEMVER_REGEX}
+ */
+const isExplicitSemver = async (version: string): Promise<boolean> => {
+  return SEMVER_REGEX.test(version);
+};
+
+/**
+ * Verifies if a version string is a semver alias
+ * @see FUZZY_SEMVER_REGEX
+ *
+ * @param version The tested version string
+ * @returns If the version is an explicit semver
+ */
+const isSemverAlias = async (version: string): Promise<boolean> => {
+  return !SEMVER_REGEX.test(version) && FUZZY_SEMVER_REGEX.test(version);
+};
+
+/**
+ * Verifies if a version string is any type of semver
+ *
+ * @param version The tested version string
+ * @returns If the version is any type of semver
+ */
+const isAnySemver = async (version: string): Promise<boolean> => {
+  return (
+    EXTENDED_SEMVER_REGEX.test(version) || FUZZY_SEMVER_REGEX.test(version)
+  );
+};
 
 const getMatchingVersions = async (
   versionList: string[],
@@ -13,7 +66,7 @@ const getMatchingVersions = async (
   channel: string,
   prereleaseChannels: string[],
 ): Promise<string[]> => {
-  const isTargetExplicitSemver = FUZZY_SEMVER_REGEX.test(targetVersion);
+  const isTargetNonPrereleaseSemver = FUZZY_SEMVER_REGEX.test(targetVersion);
 
   return versionList
     .filter((version) => {
@@ -22,7 +75,7 @@ const getMatchingVersions = async (
         return false;
       }
 
-      if (isTargetExplicitSemver && SEMVER_REGEX.test(version)) {
+      if (isTargetNonPrereleaseSemver && isExplicitSemver(version)) {
         // Ex: 2.1 should capture 2.1.3, 2.1.4, 2.1.5, but not 2.2.0
         return version.startsWith(targetVersion);
       }
@@ -38,6 +91,9 @@ const getMatchingVersions = async (
 
 export {
   getMatchingVersions,
+  isExplicitSemver,
+  isAnySemver,
+  isSemverAlias,
   SEMVER_REGEX,
   EXTENDED_SEMVER_REGEX,
   FUZZY_SEMVER_REGEX,

--- a/test/commands/install.test.ts
+++ b/test/commands/install.test.ts
@@ -140,6 +140,24 @@ describe('Install Command', () => {
     expect(err.message).toBe('unable to find version');
   });
 
+  it('will warn and exit if an alias is used', async () => {
+    config.pjson.oclif.update.s3.host = 'https://test-cli-oclif.com/';
+    mockFs.readdirSync.mockReturnValue([] as any);
+    commandInstance = new MockedInstallCommand(['2'], config);
+
+    let err;
+
+    try {
+      await commandInstance.run();
+    } catch (error) {
+      err = error;
+    }
+
+    expect(err.message).toBe(
+      `We do not yet support major/minor aliases with the install command. Please refer to this issue for updates: https://github.com/sumwatshade/plugin-update/issues/32`,
+    );
+  });
+
   it('will handle an invalid channel request', async () => {
     config.pjson.oclif.update.s3.host = 'https://test-cli-oclif.com/';
     mockFs.readdirSync.mockReturnValue([] as any);


### PR DESCRIPTION
- DRY usage of the semver regexes
- For update and install, detect alias usage and throw an error for the user