### PR TITLE
fix: null checking on client root

### DIFF
--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -60,9 +60,12 @@ export default class InstallCommand extends UpdateCommand {
       this.channel = 'stable';
     }
 
-    const versions = fs
-      .readdirSync(this.clientRoot)
-      .filter((dirOrFile) => dirOrFile !== 'bin' && dirOrFile !== 'current');
+    let versions: string[] = [];
+    try {
+      versions = fs
+        .readdirSync(this.clientRoot)
+        .filter((dirOrFile) => dirOrFile !== 'bin' && dirOrFile !== 'current');
+    } catch {}
 
     if (versions.includes(targetVersion)) {
       this.log(

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -71,9 +71,15 @@ export default class UpdateCommand extends Command {
       );
 
       // Do not show known non-local version folder names, bin and current.
-      const versions = fs
-        .readdirSync(this.clientRoot)
-        .filter((dirOrFile) => dirOrFile !== 'bin' && dirOrFile !== 'current');
+      let versions: string[] = [];
+      try {
+        versions = fs
+          .readdirSync(this.clientRoot)
+          .filter(
+            (dirOrFile) => dirOrFile !== 'bin' && dirOrFile !== 'current',
+          );
+      } catch {}
+
       if (versions.length === 0)
         throw new Error('No locally installed versions found.');
 

--- a/src/commands/use.ts
+++ b/src/commands/use.ts
@@ -53,9 +53,12 @@ export default class UseCommand extends UpdateCommand {
     this.debug(`Looking for locally installed versions at ${this.clientRoot}`);
 
     // Do not show known non-local version folder names, bin and current.
-    const versions = fs
-      .readdirSync(this.clientRoot)
-      .filter((dirOrFile) => dirOrFile !== 'bin' && dirOrFile !== 'current');
+    let versions: string[] = [];
+    try {
+      versions = fs
+        .readdirSync(this.clientRoot)
+        .filter((dirOrFile) => dirOrFile !== 'bin' && dirOrFile !== 'current');
+    } catch {}
 
     // Back out if no local versions are found
     if (versions.length === 0)


### PR DESCRIPTION
This checks if the client directory has been created prior to checking for available versions. If this is the first installation, there might not be a client directory.